### PR TITLE
New indexable TensorizedTensor

### DIFF
--- a/doc/dev_guide/api.rst
+++ b/doc/dev_guide/api.rst
@@ -1,8 +1,8 @@
+=============
 Style and API
 =============
 
 In TensorLy-Torch (and more generally in the TensorLy project),
 we try to maintain a simple and consistent API.
 
-Here are some elements to consider.
-
+Here are some elements to consider  *Coming Soon* 

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -9,6 +9,7 @@ It builds on top of `TensorLy <tensorly.org>`_ and enables anyone to use tensor 
 
 .. toctree::
 
+   factorized_tensors
    trl
    factorized_conv
    tensorized_linear

--- a/tltorch/__init__.py
+++ b/tltorch/__init__.py
@@ -8,6 +8,7 @@ from . import factorized_layers
 
 from .factorized_layers import FactorizedLinear, FactorizedConv, TRL, TCL
 from .factorized_tensors import FactorizedTensor, CPTensor, TTTensor, TuckerTensor, tensor_init
-from .factorized_tensors import TensorizedMatrix, CPMatrix, TuckerMatrix, TTMatrix
+from .factorized_tensors import (TensorizedTensor, CPTensorized, BlockTT,
+                                  TuckerTensorized)
 from .tensor_hooks import (tensor_lasso, remove_tensor_lasso,
                            tensor_dropout, remove_tensor_dropout)

--- a/tltorch/factorized_layers/factorized_linear.py
+++ b/tltorch/factorized_layers/factorized_linear.py
@@ -4,7 +4,7 @@ from torch import nn
 import torch
 
 from ..functional import factorized_linear
-from ..factorized_tensors import TensorizedMatrix
+from ..factorized_tensors import TensorizedTensor
 
 # Author: Jean Kossaifi
 # License: BSD 3 clause
@@ -52,11 +52,15 @@ class FactorizedLinear(nn.Module):
 
         self.rank = rank
         self.n_layers = n_layers
-
-        if isinstance(factorization, TensorizedMatrix):
+        if n_layers > 1:
+            tensor_shape = (n_layers, out_tensorized_features, in_tensorized_features)
+        else:
+            tensor_shape = (out_tensorized_features, in_tensorized_features)
+        
+        if isinstance(factorization, TensorizedTensor):
             self.weight = factorization
         else:
-            self.weight = TensorizedMatrix.new(out_tensorized_features, in_tensorized_features, rank=rank, n_matrices=n_layers, factorization=factorization)
+            self.weight = TensorizedTensor.new(tensor_shape, rank=rank, factorization=factorization)
         self.rank = self.weight.rank
 
     def reset_parameters(self):

--- a/tltorch/factorized_layers/tests/test_factorized_linear.py
+++ b/tltorch/factorized_layers/tests/test_factorized_linear.py
@@ -1,13 +1,13 @@
 import pytest 
 from torch import nn
 from ..factorized_linear import FactorizedLinear
-from ... import TensorizedMatrix
+from ... import TensorizedTensor
 
 import tensorly as tl
 tl.set_backend('pytorch')
 from tensorly import testing
 
-@pytest.mark.parametrize('factorization', ['CP', 'Tucker', 'TT', 'TTM'])
+@pytest.mark.parametrize('factorization', ['CP', 'Tucker', 'BlockTT'])
 def test_FactorizedLinear(factorization):
     random_state = 12345
     rng = tl.check_random_state(random_state)
@@ -19,7 +19,7 @@ def test_FactorizedLinear(factorization):
     data = tl.tensor(rng.random_sample((batch_size, in_features)))
 
     # Creat from a tensor factorization
-    tensor = TensorizedMatrix.new(out_shape, in_shape, rank='same', factorization=factorization)
+    tensor = TensorizedTensor.new((out_shape, in_shape), rank='same', factorization=factorization)
     tensor.normal_()
     fc = nn.Linear(in_features, out_features, bias=True)
     fc.weight.data = tensor.to_matrix()

--- a/tltorch/factorized_tensors/__init__.py
+++ b/tltorch/factorized_tensors/__init__.py
@@ -1,5 +1,5 @@
-from .factorized_tensor import (CPTensor, TuckerTensor, TTTensor,
-                                FactorizedTensor, TTMatrix)
-from .tensorized_matrices import (TensorizedMatrix, CPMatrix, TTMatrix,
-                                  TuckerMatrix)
+from .factorized_tensors import (CPTensor, TuckerTensor, TTTensor,
+                                FactorizedTensor)
+from .tensorized_matrices import (TensorizedTensor, CPTensorized, BlockTT,
+                                  TuckerTensorized)
 from .init import tensor_init, cp_init, tucker_init, tt_init, tt_matrix_init

--- a/tltorch/factorized_tensors/factorized_tensors.py
+++ b/tltorch/factorized_tensors/factorized_tensors.py
@@ -1,4 +1,5 @@
 import math
+from collections import Iterable
 
 import numpy as np
 import torch
@@ -7,7 +8,7 @@ from torch import nn
 import tensorly as tl
 tl.set_backend('pytorch')
 from tensorly import tenalg
-from tensorly.decomposition import parafac, tucker, tensor_train, tensor_train_matrix
+from tensorly.decomposition import parafac, tucker, tensor_train
 
 from .core import FactorizedTensor
 from ..utils import FactorList
@@ -96,7 +97,7 @@ class CPTensor(FactorizedTensor, name='CP'):
         elif isinstance(indices, slice):
             # Index part of a factor
             mixing_factor, *factors = self.factors
-            factors = [mixing_factor[indices], *factors]
+            factors = [mixing_factor[indices, :], *factors]
             weights = self.weights
             return self.__class__(weights, factors)
 
@@ -110,14 +111,14 @@ class CPTensor(FactorizedTensor, name='CP'):
                     raise ValueError(f'Ellipsis is not yet supported, yet got indices={indices} which contains one.')
 
                 mixing_factor, *factors = factors
-                if isinstance(index, int):
+                if isinstance(index,  (np.integer, int)):
                     if factors or index_factors:
                         weights = weights*mixing_factor[index, :]
                     else:
                         # No factors left
                         return tl.sum(weights*mixing_factor[index, :])
                 else:
-                    index_factors.append(mixing_factor[index])
+                    index_factors.append(mixing_factor[index, :])
             
             return self.__class__(weights, index_factors + factors)
         # return self.__class__(*tl.cp_indexing(self.weights, self.factors, indices))
@@ -161,11 +162,14 @@ class TuckerTensor(FactorizedTensor, name='Tucker'):
     shape
     rank
     """
-    def __init__(self, core, factors):
+    def __init__(self, core, factors, shape=None, rank=None):
         super().__init__()
-        self.shape, self.rank = tl.tucker_tensor._validate_tucker_tensor((core, factors))
+        if shape is not None and rank is not None:
+            self.shape, self.rank = shape, rank
+        else:
+            self.shape, self.rank = tl.tucker_tensor._validate_tucker_tensor((core, factors))
+        
         self.order = len(self.shape)
-
         setattr(self, 'core', core)
         self.factors = FactorList(factors)
     
@@ -262,12 +266,12 @@ class TuckerTensor(FactorizedTensor, name='Tucker'):
             # Select one dimension of one mode
             mixing_factor, *factors = self.factors
             core = tenalg.mode_dot(self.core, mixing_factor[indices, :], 0)
-            return TuckerTensor(core, factors)
+            return core, factors
         
         elif isinstance(indices, slice):
             mixing_factor, *factors = self.factors
-            factors = [mixing_factor[indices], *factors]
-            return TuckerTensor(self.core, factors)
+            factors = [mixing_factor[indices, :], *factors]
+            return self.__class__(self.core, factors)
         
         else:
             # Index multiple dimensions
@@ -279,15 +283,15 @@ class TuckerTensor(FactorizedTensor, name='Tucker'):
                     raise ValueError(f'Ellipsis is not yet supported, yet got indices={indices}, indices[{i}]={index}.')
                 if isinstance(index, int):
                     modes.append(i)
-                    factors_contract.append(factor[index])
+                    factors_contract.append(factor[index, :])
                 else:
-                    factors.append(factor[index])
+                    factors.append(factor[index, :])
 
             core = tenalg.multi_mode_dot(self.core, factors_contract, modes=modes)
             factors = factors + self.factors[i+1:]
 
             if factors:
-                return TuckerTensor(core, factors)
+                return self.__class__(core, factors)
 
             # Fully contracted tensor
             return core
@@ -436,90 +440,7 @@ class TTTensor(FactorizedTensor, name='TT'):
             # Below: <=> static prediciton
             # new_factor[:, new_dim//2, :] = torch.eye(new_rank)
 
-
         factors.insert(mode, nn.Parameter(new_factor.to(factors[0].device)))
         self.factors = FactorList(factors)
 
         return self
-
-
-class TTMatrix(FactorizedTensor, name='TTM'):
-    """Tensor-Train Matrix (MPO) Factorization
-
-    Parameters
-    ----------
-    factors
-    shape
-    rank
-    """
-    def __init__(self, factors, shape=None, rank=None):
-        if shape is None or rank is None:
-            self.shape, self.rank = tl.tt_matrix._validate_tt_matrix(factors)
-        else:
-            self.shape, self.rank = shape, rank
-
-        n_dim = len(self.tensorized_shape) // 2
-        tensorized_rows_shape = np.prod(self.tensorized_shape[:n_dim])
-        tensorized_columns_shape = np.prod(self.tensorized_shape[n_dim:])
-        self.shape = (tensorized_rows_shape, tensorized_columns_shape)
-        self.order = len(self.shape)
-
-        self.factors = FactorList(factors)
-    
-    @classmethod
-    def new(cls, tensorized_shape, rank, **kwargs):
-
-        n_dim = len(tensorized_shape) // 2
-        if n_dim*2 == len(tensorized_shape):
-            n_matrices = 1
-        else:
-            n_matrices = tensorized_shape[0]
-            tensorized_shape = tensorized_shape[1:]
-
-        rank = tl.tt_matrix.validate_tt_matrix_rank(tensorized_shape, rank)
-
-        tensorized_row_shape = tensorized_shape[:n_dim]
-        tensorized_column_shape = tensorized_shape[n_dim:]
-
-        if n_matrices == 1:
-            factors = [nn.Parameter(torch.Tensor(rank[i], tensorized_row_shape[i], tensorized_column_shape[i], rank[i + 1]))\
-                        for i in range(len(tensorized_row_shape))]
-        else:
-            factors = [nn.Parameter(torch.Tensor(n_matrices, rank[i], tensorized_row_shape[i], tensorized_column_shape[i], rank[i + 1]))\
-                        for i in range(len(tensorized_row_shape))]
-        
-        return cls(factors)
-
-    @classmethod
-    def from_tensor(cls, tensor, rank='same', **kwargs):
-        tensorized_shape = tensor.shape
-        rank = tl.tt_matrix.validate_tt_matrix_rank(tensorized_shape, rank)
-
-        with torch.no_grad():
-            factors = tensor_train_matrix(tensor, rank, **kwargs)
-        
-        return cls([nn.Parameter(f) for f in factors])
-
-    def init_from_tensor(self, tensor, **kwargs):
-        with torch.no_grad():
-            factors = tensor_train_matrix(tensor, self.rank, **kwargs)
-        
-        self.factors = FactorList([nn.Parameter(f) for f in factors])
-        return self
-
-    @property
-    def decomposition(self):
-        return self.factors
-
-    def to_tensor(self):
-        return tl.tt_matrix_to_matrix(self.decomposition)
-
-    def extra_repr(self):
-        return f'shape={self.shape}, tensorized_shape={self.tensorized_shape}, rank={self.rank}, order={self.order}'
-    
-    def __torch_function__(self, func, types, args=(), kwargs=None):
-        if kwargs is None:
-            kwargs = {}
-
-        args = [t.to_tensor() if hasattr(t, 'to_tensor') else t for t in args]
-        return func(*args, **kwargs)

--- a/tltorch/factorized_tensors/init.py
+++ b/tltorch/factorized_tensors/init.py
@@ -7,7 +7,7 @@
 import torch
 import math
 import numpy as np
-from .factorized_tensor import FactorizedTensor
+from .factorized_tensors import FactorizedTensor
 
 import tensorly as tl
 tl.set_backend('pytorch')

--- a/tltorch/functional/linear.py
+++ b/tltorch/functional/linear.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 import torch.nn.functional as F
-from ..factorized_tensors import TensorizedMatrix
+from ..factorized_tensors import TensorizedTensor
 
 import tensorly as tl
 tl.set_backend('pytorch')
@@ -19,11 +19,11 @@ def factorized_linear(x, weight, bias=None, in_features=None):
     if not torch.is_tensor(weight):
         # Weights are in the form (out_features, in_features) 
         # PyTorch's linear returns dot(x, weight.T)!
-        if isinstance(weight, TensorizedMatrix):
+        if isinstance(weight, TensorizedTensor):
             weight = weight.to_matrix()
         else:
-            weight = torch.reshape(weight.to_tensor(), (-1, in_features))
+            weight = weight.to_tensor()
 
 
-    return F.linear(x, weight, bias=bias)
+    return F.linear(x, torch.reshape(weight, (-1, in_features)), bias=bias)
 


### PR DESCRIPTION
This creates a new class, TensorizedTensor, which replaces and generalizes TensorizedMatrix. 
It can represent arbitrary tensorized tensors (including vectors, matrices, batched matrices, etc) and supports generalized indexing. 

The proper generalized indexing for Tucker still remains to be done. 
I am thinking of merging these "tensorizedTensors" with regular factorized tensors and just giving the option of having either regular tensors or tensorized ones. 



The idea is to have a `tensor_shape`.

For a regular tensor, that's just a tuple of ints, e.g. `(2, 3, 4)`.
To create a tensorized_tensor, one simply passes a nested tuple: `(2, (2, 3, 4), (3, 4, 5))`.

When indexing a tensorized_tensor, I iterate through this tensor shape and:
1. if the current element is an int, I index it (in the case of block decomposition it represents a batched dimension!)
2. if the current element is a shape, we're dealing with a tensorized dimension, I convert the index into indices for each of the tensorized dims.

I've generalized the concept of TTMatrix to any orders and consequently renamed it BlockTT, to differentiate it from TT. In a block TT, the above shape `(2, (2, 3, 4), (3, 4, 5))` will result in a batch size of 2 and two dimensions, tensorized respectively to (2, 3, 4) and (3, 4, 5). 