### PR TITLE
Add missing parentheses to contiguous core call. Also add to factors

### DIFF
--- a/tltorch/factorized_tensors/factorized_tensors.py
+++ b/tltorch/factorized_tensors/factorized_tensors.py
@@ -191,7 +191,7 @@ class TuckerTensor(FactorizedTensor, name='Tucker'):
         with torch.no_grad():
             core, factors = tucker(tensor, rank, **kwargs)
         
-        return cls(nn.Parameter(core.contiguous), [nn.Parameter(f) for f in factors])
+        return cls(nn.Parameter(core.contiguous()), [nn.Parameter(f.contiguous()) for f in factors])
 
     def init_from_tensor(self, tensor, unsqueezed_modes=None, unsqueezed_init='average', **kwargs):
         """Initialize the tensor factorization from a tensor


### PR DESCRIPTION
This PR adds missing parentheses, and also adds a precautionary `.contiguous()` call to the factors.