### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/tltorch/factorized_tensors/tensorized_matrices.py
+++ b/tltorch/factorized_tensors/tensorized_matrices.py
@@ -124,7 +124,6 @@ class CPTensorized(CPTensor, TensorizedTensor, name='CP'):
         output_shape.extend(self.tensorized_shape[len(indices):])
         
         if indexed_factors:
-            print(output_shape)
             return self.__class__(weights, indexed_factors, tensorized_shape=output_shape)
         return tl.sum(weights)
 


### PR DESCRIPTION
I think this line is unnecessary, and triggers a print statement at every forward indexing call of the tensorized embedding layer.