### PR TITLE
Remove unused import that is not a dependency

### DIFF
--- a/tltorch/functional/linear.py
+++ b/tltorch/functional/linear.py
@@ -1,4 +1,3 @@
-from tkinter import W
 import numpy as np
 import torch
 import torch.nn.functional as F


### PR DESCRIPTION
Removing tkinter which is imported but not used.

It also throws an error since it is not a dependency.