### PR TITLE
Replacing collections with collections.abc for Python 3.10 support

### DIFF
--- a/tltorch/factorized_tensors/factorized_tensors.py
+++ b/tltorch/factorized_tensors/factorized_tensors.py
@@ -1,5 +1,5 @@
 import math
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import torch

--- a/tltorch/factorized_tensors/tensorized_matrices.py
+++ b/tltorch/factorized_tensors/tensorized_matrices.py
@@ -1,5 +1,5 @@
 import math
-from collections import Iterable
+from collections.abc import Iterable
 import warnings
 
 import numpy as np


### PR DESCRIPTION
just a minimum PR to be compatible with newer Python versions. See here: https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes